### PR TITLE
condition should test if variable is defined

### DIFF
--- a/templates/smartd.conf.j2
+++ b/templates/smartd.conf.j2
@@ -28,7 +28,7 @@
 	{%- if 'mail_recipients' in config %}
 		{{- " -m " }}{{ config.mail_recipients | join(",") }}
 		{{- " -M " }}{{ config.mail_frequency | d(smartd_default_mail_frequency) -}}
-		{%- if config.mail_script %}
+		{%- if config.mail_script is defined %}
 			{{- " -M " }}{{ config.mail_script -}}
 		{%- endif %}
 	{%- endif %}


### PR DESCRIPTION
added »is defined« 
otherwise a defined Emailaddress but undefined smartd_mail_script would throw an error.