### PR TITLE
added newline

### DIFF
--- a/templates/smartd.conf.j2
+++ b/templates/smartd.conf.j2
@@ -59,5 +59,5 @@
 	{%- for format in config.vendor_formats | d([]) %}{{ " -v " }}
 		{{- format -}}
 	{%- endfor %}
-	{{- " -P " }}{{ config.preset_mode | d(smartd_default_preset_mode) -}}
+	{{- " -P " }}{{ config.preset_mode | d(smartd_default_preset_mode) -}}{{'\n'}}
 {% endfor %}


### PR DESCRIPTION
without newline, all defined harddrives and DEVICESCAN entries would be in one loong line.