### PR TITLE
Ensure that the smartd monitor is enabled

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,4 +3,5 @@
   service:
     name: smartd.service
     state: restarted
+    enabled: yes
 ...


### PR DESCRIPTION
Allows us to be more deterministic. Let's not trust the package maintainer's idea about smartd enablement.