### PR TITLE
Separate mail recipients and directives

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,9 +15,10 @@ smartd_default_report_error_types:
 smartd_default_non_smart_settings:
   - lookahead,on
 smartd_default_test_schedule: (L/../../6/01|S/../.././02)
-smartd_default_mail_frequency: diminishing
-smartd_default_mail_script:
-smartd_default_mail_recipients: []
+smartd_default_mail_directives:
+  - diminishing
+smartd_default_mail_recipients:
+  - root
 smartd_default_report_ata_failure: True
 smartd_default_report_ata_prefail: True
 smartd_default_report_ata_usage: False

--- a/templates/smartd.conf.j2
+++ b/templates/smartd.conf.j2
@@ -31,13 +31,16 @@
 	{%- if config.test_schedule | d(smartd_default_test_schedule) %}
 		{{- " -s " }}{{ config.test_schedule | d(smartd_default_test_schedule) -}}{{' \\\n'}}
 	{%- endif %}
-	{%- if 'mail_recipients' in config or smartd_default_mail_recipients %}
-        {{- " -m " }}{{ config.mail_recipients | d(smartd_default_mail_recipients) | join(",") -}}{{' \\\n'}}
-		{{- " -M " }}{{ config.mail_frequency | d(smartd_default_mail_frequency) -}}{{' \\\n'}}
-		{%- if config.mail_script | d(smartd_default_mail_script) %}
-			{{- " -M exec " }}{{ config.mail_script | d(smartd_default_mail_script) -}}{{' \\\n'}}
-		{%- endif %}
+	{%- if "mail_recipients" in config %}
+		{{- " -m " ~ config.mail_recipients | d(smartd_default_mail_recipients) | join(",") ~ " \\\n"}}
 	{%- endif %}
+	{%- for directive in config.mail_directives | d(smartd_default_mail_directives) %}
+		{%- if directive in ["once", "daily", "diminishing"] and "mail_recipients" not in config -%}
+			{{ none }}
+		{%- else -%}
+			{{- " -M " ~ directive ~ " \\\n"}}
+		{%- endif -%}
+	{%- endfor %}
 	{%- if config.report_ata_failure | d(smartd_default_report_ata_failure) %}
 		{{- " -f" -}}
 	{%- endif %}


### PR DESCRIPTION
Some scripts included among the smarmontools examples are built to work with `-m ADDR -M exec /path/to/script.sh` and some are built to work with just `-M exec /path/to/script`.
Current template only allows `-M exec` when `mail_recipients` is defined and automatically include a default `mail_frequency`.